### PR TITLE
Add timeout to `requests` calls

### DIFF
--- a/llava/eval/run_llava.py
+++ b/llava/eval/run_llava.py
@@ -16,7 +16,7 @@ from io import BytesIO
 
 def load_image(image_file):
     if image_file.startswith('http') or image_file.startswith('https'):
-        response = requests.get(image_file)
+        response = requests.get(image_file, timeout=60)
         image = Image.open(BytesIO(response.content)).convert('RGB')
     else:
         image = Image.open(image_file).convert('RGB')

--- a/llava/serve/cli.py
+++ b/llava/serve/cli.py
@@ -17,7 +17,7 @@ from transformers import TextStreamer
 
 def load_image(image_file):
     if image_file.startswith('http://') or image_file.startswith('https://'):
-        response = requests.get(image_file)
+        response = requests.get(image_file, timeout=60)
         image = Image.open(BytesIO(response.content)).convert('RGB')
     else:
         image = Image.open(image_file).convert('RGB')

--- a/llava/serve/gradio_web_server.py
+++ b/llava/serve/gradio_web_server.py
@@ -36,9 +36,9 @@ def get_conv_log_filename():
 
 
 def get_model_list():
-    ret = requests.post(args.controller_url + "/refresh_all_workers")
+    ret = requests.post(args.controller_url + "/refresh_all_workers", timeout=60)
     assert ret.status_code == 200
-    ret = requests.post(args.controller_url + "/list_models")
+    ret = requests.post(args.controller_url + "/list_models", timeout=60)
     models = ret.json()["models"]
     models.sort(key=lambda x: priority.get(x, x))
     logger.info(f"Models: {models}")
@@ -198,7 +198,7 @@ def http_bot(state, model_selector, temperature, top_p, max_new_tokens, request:
     # Query worker address
     controller_url = args.controller_url
     ret = requests.post(controller_url + "/get_worker_address",
-            json={"model": model_name})
+            json={"model": model_name}, timeout=60)
     worker_addr = ret.json()["address"]
     logger.info(f"model_name: {model_name}, worker_addr: {worker_addr}")
 

--- a/llava/serve/model_worker.py
+++ b/llava/serve/model_worker.py
@@ -81,7 +81,7 @@ class ModelWorker:
             "check_heart_beat": True,
             "worker_status": self.get_status()
         }
-        r = requests.post(url, json=data)
+        r = requests.post(url, json=data, timeout=60)
         assert r.status_code == 200
 
     def send_heart_beat(self):

--- a/llava/serve/register_worker.py
+++ b/llava/serve/register_worker.py
@@ -22,5 +22,5 @@ if __name__ == "__main__":
         "check_heart_beat": args.check_heart_beat,
         "worker_status": None,
     }
-    r = requests.post(url, json=data)
+    r = requests.post(url, json=data, timeout=60)
     assert r.status_code == 200

--- a/llava/serve/test_message.py
+++ b/llava/serve/test_message.py
@@ -11,14 +11,14 @@ def main():
         worker_addr = args.worker_address
     else:
         controller_addr = args.controller_address
-        ret = requests.post(controller_addr + "/refresh_all_workers")
-        ret = requests.post(controller_addr + "/list_models")
+        ret = requests.post(controller_addr + "/refresh_all_workers", timeout=60)
+        ret = requests.post(controller_addr + "/list_models", timeout=60)
         models = ret.json()["models"]
         models.sort()
         print(f"Models: {models}")
 
         ret = requests.post(controller_addr + "/get_worker_address",
-            json={"model": args.model_name})
+            json={"model": args.model_name}, timeout=60)
         worker_addr = ret.json()["address"]
         print(f"worker_addr: {worker_addr}")
 
@@ -38,7 +38,7 @@ def main():
         "stop": conv.sep,
     }
     response = requests.post(worker_addr + "/worker_generate_stream", headers=headers,
-            json=pload, stream=True)
+            json=pload, stream=True, timeout=60)
 
     print(prompt.replace(conv.sep, "\n"), end="")
     for chunk in response.iter_lines(chunk_size=8192, decode_unicode=False, delimiter=b"\0"):

--- a/sgm/modules/autoencoding/lpips/util.py
+++ b/sgm/modules/autoencoding/lpips/util.py
@@ -15,7 +15,7 @@ MD5_MAP = {"vgg_lpips": "d507d7349b931f0638a25a48a722f98a"}
 
 def download(url, local_path, chunk_size=1024):
     os.makedirs(os.path.split(local_path)[0], exist_ok=True)
-    with requests.get(url, stream=True) as r:
+    with requests.get(url, stream=True, timeout=60) as r:
         total_size = int(r.headers.get("content-length", 0))
         with tqdm(total=total_size, unit="B", unit_scale=True) as pbar:
             with open(local_path, "wb") as f:


### PR DESCRIPTION
Many developers will be surprised to learn that `requests` library calls do not include timeouts by default. This means that an attempted request could hang indefinitely if no connection is established or if no data is received from the server. 

The [requests documentation](https://requests.readthedocs.io/en/latest/user/advanced/#timeouts) suggests that most calls should explicitly include a `timeout` parameter. This codemod adds a default timeout value in order to set an upper bound on connection times and ensure that requests connect or fail in a timely manner. This value also ensures the connection will timeout if the server does not respond with data within a reasonable amount of time. 

While timeout values will be application dependent, we believe that this codemod adds a reasonable default that serves as an appropriate ceiling for most situations. 

Our changes look like the following:
```diff
 import requests
 
- requests.get("http://example.com")
+ requests.get("http://example.com", timeout=60)
```

<details>
  <summary>More reading</summary>

  * [https://docs.python-requests.org/en/master/user/quickstart/#timeouts](https://docs.python-requests.org/en/master/user/quickstart/#timeouts)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/add-requests-timeouts](https://docs.pixee.ai/codemods/python/pixee_python_add-requests-timeouts)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Python%2FSUPIR%7Cf77a20e69e52d84770d91870c7204f76e1abe1f5)

<!--{"type":"DRIP","codemod":"pixee:python/add-requests-timeouts"}-->