### PR TITLE
Simplify Boolean Expressions Using `startswith` and `endswith`

### DIFF
--- a/llava/eval/run_llava.py
+++ b/llava/eval/run_llava.py
@@ -15,7 +15,7 @@ from io import BytesIO
 
 
 def load_image(image_file):
-    if image_file.startswith('http') or image_file.startswith('https'):
+    if image_file.startswith(('http', 'https')):
         response = requests.get(image_file)
         image = Image.open(BytesIO(response.content)).convert('RGB')
     else:

--- a/llava/eval/summarize_gpt_review.py
+++ b/llava/eval/summarize_gpt_review.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
     if len(args.files) > 0:
         review_files = args.files
     else:
-        review_files = [x for x in os.listdir(args.dir) if x.endswith('.jsonl') and (x.startswith('gpt4_text') or x.startswith('reviews_') or x.startswith('review_') or 'review' in args.dir)]
+        review_files = [x for x in os.listdir(args.dir) if x.endswith('.jsonl') and (x.startswith(('gpt4_text', 'reviews_')) or x.startswith('review_') or 'review' in args.dir)]
 
     for review_file in sorted(review_files):
         config = os.path.basename(review_file).replace('gpt4_text_', '').replace('.jsonl', '')

--- a/llava/serve/cli.py
+++ b/llava/serve/cli.py
@@ -16,7 +16,7 @@ from transformers import TextStreamer
 
 
 def load_image(image_file):
-    if image_file.startswith('http://') or image_file.startswith('https://'):
+    if image_file.startswith(('http://', 'https://')):
         response = requests.get(image_file)
         image = Image.open(BytesIO(response.content)).convert('RGB')
     else:


### PR DESCRIPTION
Many developers are not necessarily aware that the `startswith` and `endswith` methods of `str` objects can accept a tuple of strings to match. This means that there is a lot of code that uses boolean expressions such as `x.startswith('foo') or x.startswith('bar')` instead of the simpler expression `x.startswith(('foo', 'bar'))`.

This codemod simplifies the boolean expressions where possible which leads to cleaner and more concise code.

The changes from this codemod look like this:

```diff
  x = 'foo'
- if x.startswith("foo") or x.startswith("bar"):
+ if x.startswith(("foo", "bar")):
     ...
```

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/combine-startswith-endswith](https://docs.pixee.ai/codemods/python/pixee_python_combine-startswith-endswith)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Python%2FSUPIR%7C12882db30fcedf89e852531ec452d7a5975881bb)

<!--{"type":"DRIP","codemod":"pixee:python/combine-startswith-endswith"}-->